### PR TITLE
Remove "docker-compose" alias from docker:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM docker:latest
 
+RUN rm /usr/local/bin/docker-compose
+
 COPY requirements.txt /tmp/requirements.txt
 
 RUN apk add --no-cache py3-pip python3-dev libffi-dev openssl-dev curl gcc libc-dev rust cargo make && \


### PR DESCRIPTION
Close #33 #32 
The latest build introduced a breaking change and forced upon users the compose CLI v2 that embraced the newer compose-spec. This patch restores the "docker-compose" to the expected v1.

Thus, users are encouraged to migrate whenever possible to v2 (_by using directly `docker:latest` instead_). Beware that the ecosystem may not be ready depending on what you use, e.g. `docker stack` command does not support the newer specification.